### PR TITLE
Abstract Base Document for migrations so that a different type than IDocument

### DIFF
--- a/Mongo.Migration.Test/IntegrationTest.cs
+++ b/Mongo.Migration.Test/IntegrationTest.cs
@@ -11,7 +11,7 @@ namespace Mongo.Migration.Test
         public IntegrationTest()
         {
             _components = new ComponentRegistry();
-            _components.RegisterComponents<IDocument>(d => d.Version, (d, v) => d.Version = v);
+            _components.RegisterComponents<IDocument>(new DocumentVersionProvider());
         }
     }
 }

--- a/Mongo.Migration.Test/IntegrationTest.cs
+++ b/Mongo.Migration.Test/IntegrationTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Mongo.Migration.Documents;
 using Mongo.Migration.Services.DiContainer;
 
 namespace Mongo.Migration.Test
@@ -10,7 +11,7 @@ namespace Mongo.Migration.Test
         public IntegrationTest()
         {
             _components = new ComponentRegistry();
-            _components.RegisterComponents();
+            _components.RegisterComponents<IDocument>(d => d.Version, (d, v) => d.Version = v);
         }
     }
 }

--- a/Mongo.Migration.Test/Migrations/MigrationRunner_when_check_version.cs
+++ b/Mongo.Migration.Test/Migrations/MigrationRunner_when_check_version.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using Mongo.Migration.Documents;
 using Mongo.Migration.Exceptions;
 using Mongo.Migration.Migrations;
 using Mongo.Migration.Test.TestDoubles;
@@ -10,12 +11,12 @@ namespace Mongo.Migration.Test.Migrations
     [TestFixture]
     internal class MigrationRunner_when_check_version : IntegrationTest
     {
-        private IMigrationRunner _runner;
+        private IMigrationRunner<IDocument> _runner;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            _runner = _components.Get<IMigrationRunner>();
+            _runner = _components.Get<IMigrationRunner<IDocument>>();
         }
 
         [Test]

--- a/Mongo.Migration.Test/Migrations/MigrationRunner_when_migrating_down.cs
+++ b/Mongo.Migration.Test/Migrations/MigrationRunner_when_migrating_down.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentAssertions;
+using Mongo.Migration.Documents;
 using Mongo.Migration.Migrations;
 using Mongo.Migration.Test.TestDoubles;
 using MongoDB.Bson;
@@ -11,12 +12,12 @@ namespace Mongo.Migration.Test.Migrations
     [TestFixture]
     internal class MigrationRunner_when_migrating_down : IntegrationTest
     {
-        private IMigrationRunner _runner;
+        private IMigrationRunner<IDocument> _runner;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            _runner = _components.Get<IMigrationRunner>();
+            _runner = _components.Get<IMigrationRunner<IDocument>>();
         }
 
         [Test]

--- a/Mongo.Migration.Test/Migrations/MigrationRunner_when_migrating_up.cs
+++ b/Mongo.Migration.Test/Migrations/MigrationRunner_when_migrating_up.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentAssertions;
+using Mongo.Migration.Documents;
 using Mongo.Migration.Migrations;
 using Mongo.Migration.Test.TestDoubles;
 using MongoDB.Bson;
@@ -11,12 +12,12 @@ namespace Mongo.Migration.Test.Migrations
     [TestFixture]
     internal class MigrationRunner_when_migrating_up : IntegrationTest
     {
-        private IMigrationRunner _runner;
+        private IMigrationRunner<IDocument> _runner;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            _runner = _components.Get<IMigrationRunner>();
+            _runner = _components.Get<IMigrationRunner<IDocument>>();
         }
 
         [Test]

--- a/Mongo.Migration.Test/Services/Interceptors/MigrationInterceptorProvider_when_get_serializer.cs
+++ b/Mongo.Migration.Test/Services/Interceptors/MigrationInterceptorProvider_when_get_serializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using Mongo.Migration.Documents;
 using Mongo.Migration.Services.Interceptors;
 using Mongo.Migration.Test.TestDoubles;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ namespace Mongo.Migration.Test.Services.Interceptors
         public void When_entity_is_document_Then_provide_serializer()
         {
             // Arrange 
-            var provider = _components.Get<MigrationInterceptorProvider>();
+            var provider = _components.Get<MigrationInterceptorProvider<IDocument>>();
 
             // Act
             var serializer = provider.GetSerializer(typeof(TestDocumentWithOneMigration));
@@ -26,7 +27,7 @@ namespace Mongo.Migration.Test.Services.Interceptors
         public void When_entity_is_not_document_Then_provide_null()
         {
             // Arrange 
-            var provider = _components.Get<MigrationInterceptorProvider>();
+            var provider = _components.Get<MigrationInterceptorProvider<IDocument>>();
 
             // Act
             var serializer = provider.GetSerializer(typeof(TestClass));

--- a/Mongo.Migration/Documents/DocumentVersionProvider.cs
+++ b/Mongo.Migration/Documents/DocumentVersionProvider.cs
@@ -1,0 +1,11 @@
+﻿using Mongo.Migration.Documents.VersionProviders;
+
+namespace Mongo.Migration.Documents
+{
+    public class DocumentVersionProvider : IDocumentVersionProvider<IDocument>
+    {
+        public DocumentVersion GetVersion(IDocument document) => document.Version;
+
+        public void SetVersion(IDocument document, DocumentVersion version) => document.Version = version;
+    }
+}

--- a/Mongo.Migration/Documents/VersionProviders/IDocumentVersionProvider.cs
+++ b/Mongo.Migration/Documents/VersionProviders/IDocumentVersionProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Mongo.Migration.Documents.VersionProviders
+{
+    public interface IDocumentVersionProvider<TBaseDocument>
+    {
+        DocumentVersion GetVersion(TBaseDocument document);
+
+        void SetVersion(TBaseDocument document, DocumentVersion version);
+    }
+}

--- a/Mongo.Migration/Migrations/IMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/IMigrationRunner.cs
@@ -4,10 +4,10 @@ using MongoDB.Bson;
 
 namespace Mongo.Migration.Migrations
 {
-    internal interface IMigrationRunner
+    internal interface IMigrationRunner<TBaseDocument>
     {
         void Run(Type type, BsonDocument document);
 
-        void CheckVersion<TClass>(TClass instance) where TClass : class, IDocument;
+        void CheckVersion<TClass>(TClass instance) where TClass : class, TBaseDocument;
     }
 }

--- a/Mongo.Migration/Migrations/Locators/MigrationLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/MigrationLocator.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using Mongo.Migration.Documents;
 using Mongo.Migration.Exceptions;
 using Mongo.Migration.Extensions;
-using MongoDB.Bson.Serialization.Serializers;
 
 namespace Mongo.Migration.Migrations.Locators
 {

--- a/Mongo.Migration/Migrations/Migration{TClass,TBaseDocument}.cs
+++ b/Mongo.Migration/Migrations/Migration{TClass,TBaseDocument}.cs
@@ -4,7 +4,7 @@ using MongoDB.Bson;
 
 namespace Mongo.Migration.Migrations
 {
-    public abstract class Migration<TClass> : IMigration where TClass : class, IDocument
+    public abstract class Migration<TClass, TBaseDocument> : IMigration where TClass : class, TBaseDocument
     {
         protected Migration(string version)
         {

--- a/Mongo.Migration/Migrations/Migration{TClass}.cs
+++ b/Mongo.Migration/Migrations/Migration{TClass}.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Mongo.Migration.Documents;
+using MongoDB.Bson;
+
+namespace Mongo.Migration.Migrations
+{
+    public abstract class Migration<TClass> : Migration<TClass, IDocument> where TClass : class, IDocument
+    {
+        protected Migration(string version)
+            : base(version)
+        {
+        }
+    }
+}

--- a/Mongo.Migration/Services/DiContainer/ComponentRegistry.cs
+++ b/Mongo.Migration/Services/DiContainer/ComponentRegistry.cs
@@ -3,6 +3,7 @@ using LightInject;
 using Mongo.Migration.Documents;
 using Mongo.Migration.Documents.Locators;
 using Mongo.Migration.Documents.Serializers;
+using Mongo.Migration.Documents.VersionProviders;
 using Mongo.Migration.Migrations;
 using Mongo.Migration.Migrations.Locators;
 using Mongo.Migration.Services.Interceptors;
@@ -19,20 +20,15 @@ namespace Mongo.Migration.Services.DiContainer
             _container = new ServiceContainer();
         }
 
-        public void RegisterComponents<TBaseDocument>(Func<TBaseDocument, DocumentVersion> versionGetter, Action<TBaseDocument, DocumentVersion> versionSetter)
+        public void RegisterComponents<TBaseDocument>(IDocumentVersionProvider<TBaseDocument> documentVersionProvider)
         {
             _container.Register<DocumentVersionSerializer, DocumentVersionSerializer>();
             _container.Register<MigrationInterceptorProvider<TBaseDocument>, MigrationInterceptorProvider<TBaseDocument>>();
             _container.Register<IMigrationLocator, TypeMigrationLocator>(new PerContainerLifetime());
             _container.Register<IVersionLocator, VersionLocator>(new PerContainerLifetime());
 
-            _container.RegisterInstance<Func<TBaseDocument, DocumentVersion>>(versionGetter);
-            _container.RegisterInstance<Action<TBaseDocument, DocumentVersion>>(versionSetter);
+            _container.RegisterInstance<IDocumentVersionProvider<TBaseDocument>>(documentVersionProvider);
             _container.Register<IMigrationRunner<TBaseDocument>, MigrationRunner<TBaseDocument>>();
-
-            //_container.Register<Func<TBaseDocument, DocumentVersion>, Action<TBaseDocument, DocumentVersion>, MigrationRunner<TBaseDocument>>((factory, vGetter, vSetter) => 
-            //    new MigrationRunner<TBaseDocument>(factory.GetInstance<IMigrationLocator>(), factory.GetInstance<IVersionLocator>(), versionGetter, versionSetter));
-
 
             _container.Register<IMigrationInterceptorFactory, MigrationInterceptorFactory<TBaseDocument>>();
             _container.Register<IMongoRegistrator, MongoRegistrator<TBaseDocument>>();

--- a/Mongo.Migration/Services/DiContainer/ICompoentRegistry.cs
+++ b/Mongo.Migration/Services/DiContainer/ICompoentRegistry.cs
@@ -1,9 +1,0 @@
-namespace Mongo.Migration.Services.DiContainer
-{
-    internal interface ICompoentRegistry
-    {
-        void RegisterComponents();
-
-        TComponent Get<TComponent>() where TComponent : class;
-    }
-}

--- a/Mongo.Migration/Services/DiContainer/IComponentRegistry.cs
+++ b/Mongo.Migration/Services/DiContainer/IComponentRegistry.cs
@@ -1,11 +1,12 @@
 using System;
 using Mongo.Migration.Documents;
+using Mongo.Migration.Documents.VersionProviders;
 
 namespace Mongo.Migration.Services.DiContainer
 {
     internal interface IComponentRegistry
     {
-        void RegisterComponents<TBaseDocument>(Func<TBaseDocument, DocumentVersion> versionGetter, Action<TBaseDocument, DocumentVersion> versionSetter);
+        void RegisterComponents<TBaseDocument>(IDocumentVersionProvider<TBaseDocument> documentVersionProvider);
 
         TComponent Get<TComponent>() where TComponent : class;
     }

--- a/Mongo.Migration/Services/DiContainer/IComponentRegistry.cs
+++ b/Mongo.Migration/Services/DiContainer/IComponentRegistry.cs
@@ -1,0 +1,12 @@
+using System;
+using Mongo.Migration.Documents;
+
+namespace Mongo.Migration.Services.DiContainer
+{
+    internal interface IComponentRegistry
+    {
+        void RegisterComponents<TBaseDocument>(Func<TBaseDocument, DocumentVersion> versionGetter, Action<TBaseDocument, DocumentVersion> versionSetter);
+
+        TComponent Get<TComponent>() where TComponent : class;
+    }
+}

--- a/Mongo.Migration/Services/Initializers/MongoMigration.cs
+++ b/Mongo.Migration/Services/Initializers/MongoMigration.cs
@@ -13,7 +13,7 @@ namespace Mongo.Migration.Services.Initializers
         static MongoMigration()
         {
             _components = new ComponentRegistry();
-            _components.RegisterComponents<IDocument>(d => d.Version, (d, v) => d.Version = v);
+            _components.RegisterComponents<IDocument>(new DocumentVersionProvider());
         }
 
         public static void Initialize()

--- a/Mongo.Migration/Services/Initializers/MongoMigration{TBaseDocument}.cs
+++ b/Mongo.Migration/Services/Initializers/MongoMigration{TBaseDocument}.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Mongo.Migration.Documents;
+using Mongo.Migration.Documents.VersionProviders;
 using Mongo.Migration.Exceptions;
 using Mongo.Migration.Services.DiContainer;
 
@@ -16,10 +17,9 @@ namespace Mongo.Migration.Services.Initializers
             _components = new ComponentRegistry();
         }
 
-        public static void RegisterComponents(Func<TBaseDocument, DocumentVersion> versionGetter,
-            Action<TBaseDocument, DocumentVersion> versionSetter)
+        public static void RegisterComponents(IDocumentVersionProvider<TBaseDocument> documentVersionProvider)
         {
-            _components.RegisterComponents(versionGetter, versionSetter);
+            _components.RegisterComponents(documentVersionProvider);
         }
 
 

--- a/Mongo.Migration/Services/Initializers/MongoMigration{TBaseDocument}.cs
+++ b/Mongo.Migration/Services/Initializers/MongoMigration{TBaseDocument}.cs
@@ -1,10 +1,11 @@
-﻿using Mongo.Migration.Documents;
+﻿using System;
+using Mongo.Migration.Documents;
 using Mongo.Migration.Exceptions;
 using Mongo.Migration.Services.DiContainer;
 
 namespace Mongo.Migration.Services.Initializers
 {
-    public static class MongoMigration
+    public static class MongoMigration<TBaseDocument>
     {
         private static bool _isInitialized;
 
@@ -13,8 +14,14 @@ namespace Mongo.Migration.Services.Initializers
         static MongoMigration()
         {
             _components = new ComponentRegistry();
-            _components.RegisterComponents<IDocument>(d => d.Version, (d, v) => d.Version = v);
         }
+
+        public static void RegisterComponents(Func<TBaseDocument, DocumentVersion> versionGetter,
+            Action<TBaseDocument, DocumentVersion> versionSetter)
+        {
+            _components.RegisterComponents(versionGetter, versionSetter);
+        }
+
 
         public static void Initialize()
         {

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptor.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptor.cs
@@ -1,18 +1,15 @@
-﻿using System;
-using System.Diagnostics;
-using Mongo.Migration.Documents;
-using Mongo.Migration.Migrations;
+﻿using Mongo.Migration.Migrations;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 
 namespace Mongo.Migration.Services.Interceptors
 {
-    internal class MigrationInterceptor<TDocument> : BsonClassMapSerializer<TDocument> where TDocument : class, IDocument
+    internal class MigrationInterceptor<TDocument, TBaseDocument> : BsonClassMapSerializer<TDocument> where TDocument : class, TBaseDocument
     {
-        private readonly IMigrationRunner _migrationRunner;
+        private readonly IMigrationRunner<TBaseDocument> _migrationRunner;
 
-        public MigrationInterceptor(IMigrationRunner migrationRunner)
+        public MigrationInterceptor(IMigrationRunner<TBaseDocument> migrationRunner)
             : base(BsonClassMap.LookupClassMap(typeof(TDocument)))
         {
             _migrationRunner = migrationRunner;

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorFactory.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorFactory.cs
@@ -1,22 +1,21 @@
 ﻿using System;
-using Mongo.Migration.Documents;
 using Mongo.Migration.Migrations;
 using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
 {
-    internal class MigrationInterceptorFactory : IMigrationInterceptorFactory
+    internal class MigrationInterceptorFactory<TBaseDocument> : IMigrationInterceptorFactory
     {
-        private readonly IMigrationRunner _migrationRunner;
+        private readonly IMigrationRunner<TBaseDocument> _migrationRunner;
 
-        public MigrationInterceptorFactory(IMigrationRunner migrationRunner)
+        public MigrationInterceptorFactory(IMigrationRunner<TBaseDocument> migrationRunner)
         {
             _migrationRunner = migrationRunner;
         }
         
         public IBsonSerializer Create(Type type)
         {
-            var genericType = typeof(MigrationInterceptor<>).MakeGenericType(type);
+            var genericType = typeof(MigrationInterceptor<,>).MakeGenericType(type, typeof(TBaseDocument));
             var interceptor = Activator.CreateInstance(genericType, _migrationRunner);
             return interceptor as IBsonSerializer;
         }

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Linq;
-using Mongo.Migration.Documents;
-using Mongo.Migration.Migrations;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
 {
-    internal class MigrationInterceptorProvider : IBsonSerializationProvider
+    internal class MigrationInterceptorProvider<TBaseDocument> : IBsonSerializationProvider
     {
         private readonly IMigrationInterceptorFactory _migrationInterceptorFactory;
 
@@ -26,7 +24,7 @@ namespace Mongo.Migration.Services.Interceptors
 
         private static bool ShouldBeMigrated(Type type)
         {
-            return type.GetInterfaces().Contains(typeof(IDocument)) && type != typeof(BsonDocument);
+            return type.GetInterfaces().Contains(typeof(TBaseDocument)) && type != typeof(BsonDocument);
         }
     }
 }

--- a/Mongo.Migration/Services/MongoDB/MongoRegistrator.cs
+++ b/Mongo.Migration/Services/MongoDB/MongoRegistrator.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using Mongo.Migration.Documents;
-using Mongo.Migration.Documents.Serializers;
+﻿using Mongo.Migration.Documents.Serializers;
 using Mongo.Migration.Services.Interceptors;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.MongoDB
 {
-    internal class MongoRegistrator : IMongoRegistrator
+    internal class MongoRegistrator<TBaseDocument> : IMongoRegistrator
     {
-        private readonly MigrationInterceptorProvider _provider;
+        private readonly MigrationInterceptorProvider<TBaseDocument> _provider;
 
         private readonly DocumentVersionSerializer _serializer;
 
-        public MongoRegistrator(DocumentVersionSerializer serializer, MigrationInterceptorProvider provider)
+        public MongoRegistrator(DocumentVersionSerializer serializer, MigrationInterceptorProvider<TBaseDocument> provider)
         {
             _serializer = serializer;
             _provider = provider;


### PR DESCRIPTION
I wanted to be able to use Mongo.Migration without the need to use the IDocument that is included there. I already have an IDocument.

The purpose is that existing code will be able to run without any modification, but if I want, I can configure it to have a different TBaseDocument.

To that end, what I have done is:

- Add a generic parameter to IMigrationRunner and MigrationRunner, which would be the base document.
- I also pass in the MigrationRunner ctor the DocumentVersion getter and setter, so that I can abstract that also away.
- Add Migration<TClass, TBaseDocument>. Migration<TClass> just inherits from Migration<TClass, IDocument>
- Added TBasedocument as a parameter to ComponentRegistry. Received versionGetter and versionSetter.
- static MongoMigration would call ComponentRegistry.RegisterComponents<IDocument> with the getter and setter
- Added another static generic MongoMigration to be used when TBaseDocument is other than IDocument
- Also, passed TBaseDocument in other classes (Interceptor, InterceptorFactory, InterceptorProvider...)
- Fixed tests

Results:
- It works
- Tests pass
- Performance tests results are similar
- Although I am quite convinced with the purpose, I'm not that happy with the result. In particular, passing the getter and the setter like I do. Maybe those would be wrapped into their own abstraction, like DocumentVersionProvider<TBaseDocument>

What do you think about that? I'm asking for opinion and open to discussion

Thanks a huge lot

P.S.: And Happy x+