### PR TITLE
Add interface to MigrationInterceptorProvider

### DIFF
--- a/Mongo.Migration.Test/Services/Interceptors/MigrationInterceptorProvider_when_get_serializer.cs
+++ b/Mongo.Migration.Test/Services/Interceptors/MigrationInterceptorProvider_when_get_serializer.cs
@@ -25,7 +25,7 @@ namespace Mongo.Migration.Test.Services.Interceptors
         public void When_entity_is_document_Then_provide_serializer()
         {
             // Arrange 
-            var provider = _components.Get<MigrationInterceptorProvider>();
+            var provider = _components.Get<IMigrationInterceptorProvider>();
 
             // Act
             var serializer = provider.GetSerializer(typeof(TestDocumentWithOneMigration));
@@ -38,7 +38,7 @@ namespace Mongo.Migration.Test.Services.Interceptors
         public void When_entity_is_not_document_Then_provide_null()
         {
             // Arrange 
-            var provider = _components.Get<MigrationInterceptorProvider>();
+            var provider = _components.Get<IMigrationInterceptorProvider>();
 
             // Act
             var serializer = provider.GetSerializer(typeof(TestClass));

--- a/Mongo.Migration/Services/Interceptors/IMigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/IMigrationInterceptorProvider.cs
@@ -1,0 +1,8 @@
+﻿using MongoDB.Bson.Serialization;
+
+namespace Mongo.Migration.Services.Interceptors
+{
+    public interface IMigrationInterceptorProvider: IBsonSerializationProvider
+    {
+    }
+}

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
@@ -6,7 +6,7 @@ using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
 {
-    internal class MigrationInterceptorProvider : IBsonSerializationProvider
+    internal class MigrationInterceptorProvider : IMigrationInterceptorProvider
     {
         private readonly IMigrationInterceptorFactory _migrationInterceptorFactory;
 

--- a/Mongo.Migration/Services/MigrationService.cs
+++ b/Mongo.Migration/Services/MigrationService.cs
@@ -12,10 +12,10 @@ namespace Mongo.Migration.Services
     {
         private readonly ILogger<MigrationService> _logger;
         private readonly ICollectionMigrationRunner _migrationRunner;
-        private readonly MigrationInterceptorProvider _provider;
+        private readonly IMigrationInterceptorProvider _provider;
         private readonly DocumentVersionSerializer _serializer;
 
-        public MigrationService(DocumentVersionSerializer serializer, MigrationInterceptorProvider provider,
+        public MigrationService(DocumentVersionSerializer serializer, IMigrationInterceptorProvider provider,
             ICollectionMigrationRunner migrationRunner)
             : this(serializer, provider, NullLoggerFactory.Instance)
         {
@@ -24,7 +24,7 @@ namespace Mongo.Migration.Services
 
         private MigrationService(
             DocumentVersionSerializer serializer,
-            MigrationInterceptorProvider provider,
+            IMigrationInterceptorProvider provider,
             ILoggerFactory loggerFactory)
         {
             _serializer = serializer;

--- a/Mongo.Migration/Startup/DotNetCore/MongoMigrationExtensions.cs
+++ b/Mongo.Migration/Startup/DotNetCore/MongoMigrationExtensions.cs
@@ -37,7 +37,8 @@ namespace Mongo.Migration.Startup.DotNetCore
 
             services.AddTransient<ICollectionMigrationRunner, CollectionMigrationRunner>();
             services.AddTransient<IMigrationRunner, MigrationRunner>();
-            services.AddTransient<MigrationInterceptorProvider, MigrationInterceptorProvider>();
+            
+            services.AddTransient<IMigrationInterceptorProvider, MigrationInterceptorProvider>();
 
             services.AddTransient<IMongoMigration, MongoMigration>();
             services.AddTransient<IStartupFilter, MongoMigrationStartupFilter>();

--- a/Mongo.Migration/Startup/Static/ComponentRegistry.cs
+++ b/Mongo.Migration/Startup/Static/ComponentRegistry.cs
@@ -57,7 +57,7 @@ namespace Mongo.Migration.Startup.Static
 
             _containerAdapter.Register<ICollectionMigrationRunner, CollectionMigrationRunner>();
             _containerAdapter.Register<IMigrationRunner, MigrationRunner>();
-            _containerAdapter.Register<MigrationInterceptorProvider, MigrationInterceptorProvider>();
+            _containerAdapter.Register<IMigrationInterceptorProvider, MigrationInterceptorProvider>();
 
             _containerAdapter.Register<IMongoMigration, MongoMigration>();
         }


### PR DESCRIPTION
I have added this interface to allow the functionality to be override and extended. for my project we have inheritance within the documents meaning that the runtime migrations can really mess things up. So this allows me to but a noop serializer in.