### PR TITLE
Add not null validation to version field

### DIFF
--- a/Mongo.Migration/Services/VersionService.cs
+++ b/Mongo.Migration/Services/VersionService.cs
@@ -59,7 +59,7 @@ namespace Mongo.Migration.Services
             BsonValue value;
             document.TryGetValue(GetVersionFieldName(), out value);
 
-            if (value != null)
+            if (value != null && !value.IsBsonNull)
                 return value.AsString;
 
             return DocumentVersion.Default();


### PR DESCRIPTION
Hello, 
I enjoy using this migration tool, code written in a good clear manner,
Thank you for your time during development of this tool.

I have "Version" field in my documents and I want to reuse it for versioning,
but in this case migration throws an exception because it can't convert type BsonNull to BsonString.

Can we have this additional validation on BsonNull? 
