### PR TITLE
Support for multiple databases

### DIFF
--- a/Mongo.Migration/Migrations/CollectionMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/CollectionMigrationRunner.cs
@@ -78,11 +78,12 @@ namespace Mongo.Migration.Migrations
 
             foreach (var locate in locations)
             {
-                foreach (var dbName in _databaseNames)
+                var information = locate.Value;
+                var type = locate.Key;
+                var databaseNames = GetDatabaseOrDefault(information);
+
+                foreach (var databaseName in databaseNames)
                 {
-                    var information = locate.Value;
-                    var type = locate.Key;
-                    var databaseName = GetDatabaseOrDefault(information, dbName);
                     var collectionVersion = _versionService.GetCollectionVersion(type);
 
                     var collection = _client.GetDatabase(databaseName)
@@ -116,12 +117,12 @@ namespace Mongo.Migration.Migrations
             }
         }
 
-        private string GetDatabaseOrDefault(CollectionLocationInformation information, string dbName)
+        private string[] GetDatabaseOrDefault(CollectionLocationInformation information)
         {
-            if (string.IsNullOrEmpty(dbName) && string.IsNullOrEmpty(information.Database))
+            if (_databaseNames == null && string.IsNullOrEmpty(information.Database))
                 throw new NoDatabaseNameFoundException();
 
-            return string.IsNullOrEmpty(information.Database) ? dbName : information.Database;
+            return string.IsNullOrEmpty(information.Database) ? _databaseNames : new string[] { information.Database };
         }
 
         private FilterDefinition<BsonDocument> CreateQueryForRelevantDocuments(

--- a/Mongo.Migration/Startup/IMongoMigrationSettings.cs
+++ b/Mongo.Migration/Startup/IMongoMigrationSettings.cs
@@ -4,9 +4,9 @@ namespace Mongo.Migration.Startup
 {
     public interface IMongoMigrationSettings
     {
-        string ConnectionString { get; set; }
-        string Database { get; set; }
-        string VersionFieldName { get; set; }
-        MongoClientSettings ClientSettings { get; set; }
+        string ConnectionString { get; }
+        string[] Databases { get; }
+        string VersionFieldName { get; }
+        MongoClientSettings ClientSettings { get; }
     }
 }

--- a/Mongo.Migration/Startup/MongoMigrationSettings.cs
+++ b/Mongo.Migration/Startup/MongoMigrationSettings.cs
@@ -5,11 +5,16 @@ namespace Mongo.Migration.Startup
     public class MongoMigrationSettings : IMongoMigrationSettings
     {
         public string ConnectionString { get; set; }
-        
-        public string Database { get; set; }
+
+        public string[] Databases { get; private set; }
+
+        public string Database
+        {
+            set { this.Databases = new string[] { value }; }
+        }
 
         public string VersionFieldName { get; set; }
-        
+
         public MongoClientSettings ClientSettings { get; set; }
     }
 }

--- a/Mongo.Migration/Startup/MongoMultiDbMigrationSettings.cs
+++ b/Mongo.Migration/Startup/MongoMultiDbMigrationSettings.cs
@@ -1,0 +1,15 @@
+﻿using MongoDB.Driver;
+
+namespace Mongo.Migration.Startup
+{
+    public class MongoMultiDbMigrationSettings : IMongoMigrationSettings
+    {
+        public string ConnectionString { get; set; }
+
+        public string[] Databases { get; set; }
+
+        public string VersionFieldName { get; set; }
+
+        public MongoClientSettings ClientSettings { get; set; }
+    }
+}

--- a/NuGet/Mongo.Migration.nuspec
+++ b/NuGet/Mongo.Migration.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Mongo.Migration</id>
-    <version>3.0.108.0008</version>
+    <version>$version$</version>
     <authors>Sean Roddis (@sroddis)</authors>
     <licenseUrl>https://github.com/SRoddis/Mongo.Migration/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/SRoddis/Mongo.Migration</projectUrl>
@@ -17,7 +17,7 @@
       <dependency id="Microsoft.Extensions.DependencyInjection" version="2.2.0" />
       <dependency id="Microsoft.NETCore.App" version="2.2.0" />
       <dependency id="MongoDB.Driver" version="2.8.0" />
-      <dependency id="System.ValueTuple" version="4.5.0" />
+      <dependency id="System.ValueTuple" version="2.5.0" />
     </dependencies>
   </metadata>
   <files>

--- a/NuGet/Mongo.Migration.nuspec
+++ b/NuGet/Mongo.Migration.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Mongo.Migration</id>
-    <version>$version$</version>
+    <version>3.0.108.0008</version>
     <authors>Sean Roddis (@sroddis)</authors>
     <licenseUrl>https://github.com/SRoddis/Mongo.Migration/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/SRoddis/Mongo.Migration</projectUrl>
@@ -17,7 +17,7 @@
       <dependency id="Microsoft.Extensions.DependencyInjection" version="2.2.0" />
       <dependency id="Microsoft.NETCore.App" version="2.2.0" />
       <dependency id="MongoDB.Driver" version="2.8.0" />
-      <dependency id="System.ValueTuple" version="2.5.0" />
+      <dependency id="System.ValueTuple" version="4.5.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
I am submitting a PR that includes a few modifications intended to allow the migrations to be run on an array of databases at startup. The changes should be backwards compatible but provide a  migration settings object that exposes databases as an array or strings.