### PR TITLE
Allow the migration of individual types within a collection #26

### DIFF
--- a/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
+++ b/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NSubstitute" Version="4.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Mongo2Go" Version="2.2.11" />

--- a/Mongo.Migration.Test/IntegrationTest.cs
+++ b/Mongo.Migration.Test/IntegrationTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using LightInject;
+using Mongo.Migration.Migrations.Adapters;
 using Mongo.Migration.Startup;
 using Mongo.Migration.Startup.Static;
 using Mongo2Go;
@@ -9,8 +11,10 @@ namespace Mongo.Migration.Test
 {
     public class IntegrationTest : IDisposable
     {
+        protected const string DatabaseName = "PerformanceTest";
+        protected const string CollectionName = "Test";
         protected IMongoClient _client;
-
+        protected IContainerAdapter _containerAdapter;
         protected IComponentRegistry _components;
 
         protected MongoDbRunner _mongoToGoRunner;
@@ -20,9 +24,11 @@ namespace Mongo.Migration.Test
             _mongoToGoRunner = MongoDbRunner.Start();
             _client = new MongoClient(_mongoToGoRunner.ConnectionString);
 
-            _client.GetDatabase("PerformanceTest").CreateCollection("Test");
+            _client.GetDatabase(DatabaseName).CreateCollection(CollectionName);
 
-            _components = new ComponentRegistry( new MongoMigrationSettings() {ConnectionString = _mongoToGoRunner.ConnectionString, Database = "PerformanceTest"});
+            _containerAdapter = new LightInjectAdapter(new ServiceContainer());
+
+            _components = new ComponentRegistry( new MongoMigrationSettings() {ConnectionString = _mongoToGoRunner.ConnectionString, Database = DatabaseName }, _containerAdapter);
             _components.RegisterComponents(_client);
         }
 

--- a/Mongo.Migration.Test/Migrations/CollectionRunner_when_migrating_a_typed_document.cs
+++ b/Mongo.Migration.Test/Migrations/CollectionRunner_when_migrating_a_typed_document.cs
@@ -1,0 +1,107 @@
+﻿using Mongo.Migration.Documents.Attributes;
+using Mongo.Migration.Documents.Locators;
+using Mongo.Migration.Migrations;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mongo.Migration.Documents;
+using Mongo.Migration.Test.TestDoubles;
+using Mongo.Migration.Migrations.Locators;
+
+namespace Mongo.Migration.Test.Migrations
+{
+    public class CollectionMigrationRunner_when_migrating_a_typed_document : IntegrationTest
+    {
+        private ICollectionMigrationRunner _runner;
+        private IMongoCollection<BsonDocument> _collection;
+
+        [SetUp]
+        public async Task SetUp()
+        {
+         
+            base.OnSetUp();
+            
+            //mock ICollectionLocator for migration Type to execute
+            var collectionLocatorMock = new Mock<ICollectionLocator>();
+            collectionLocatorMock.Setup(x => x.GetLocatesOrEmpty())
+                       .Returns(new Dictionary<Type, CollectionLocationInformation>() 
+                       { 
+                           {typeof(Car), new CollectionLocationInformation(DatabaseName,CollectionName)} 
+                       });
+
+            var migrationLocatorMock = new Mock<IMigrationLocator>();
+            migrationLocatorMock.Setup(x => x.GetMigrationsFromTo(It.Is<Type>(t => t==typeof(Car)),
+                                                                  It.IsAny<DocumentVersion>(),It.IsAny<DocumentVersion>()))
+                                .Returns(new[] {new CarMigration_0_0_1() });
+
+            migrationLocatorMock.Setup(x => x.GetLatestVersion(It.Is<Type>(t => t == typeof(Car))))
+                                .Returns(new DocumentVersion(0, 0, 1));
+            
+                _containerAdapter.RegisterInstance<ICollectionLocator>(collectionLocatorMock.Object);
+            _containerAdapter.RegisterInstance<IMigrationLocator>(migrationLocatorMock.Object);
+
+            _collection = _client.GetDatabase(DatabaseName).GetCollection<BsonDocument>(CollectionName);
+            await SeedDatabaseAsync();
+
+            _runner = _components.Get<ICollectionMigrationRunner>();
+
+        }
+
+        private async Task SeedDatabaseAsync()
+        {
+            var vehicleData = new[]
+            { 
+                GetCar(),
+                GetBoat()
+            };
+
+            await _collection.InsertManyAsync(vehicleData);
+        }
+
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.Dispose();
+        }
+
+        [Test] public async Task when_migrating_a_typed_document_then_only_that_type_is_returned_in_the_batch()
+        {
+            _runner.RunAll();
+            var results = (await _collection.FindAsync(FilterDefinition<BsonDocument>.Empty)).ToList();
+            var migratedResult = results.Where(x => x.Contains("Version")).SingleOrDefault();
+
+            results.Count().Should().Be(2);
+            migratedResult.Should().NotBeNull();
+            migratedResult.Should().BeEquivalentTo(GetCarWithVersion());
+        }
+
+        #region testData
+        private static BsonDocument GetCar()
+        {
+            return new BsonDocument { { "_id", new ObjectId("5e9ff3856c9cab88f0a1cf1f") }, { "_t", new BsonArray() { "Vehicle", "Car" } }, { "Doors", 3 }, { "Type", "Cabrio" }, };
+        }
+
+        private static BsonDocument GetCarWithVersion()
+        {
+            var car = GetCar();
+            car.Add(new BsonElement("Version", "0.0.1"));
+            return car;
+        }
+
+        private static BsonDocument GetBoat()
+        {
+            return new BsonDocument { { "_id", new ObjectId("5e9ff3856c9cab88f0a1cf2f") }, { "_t", new BsonArray() { "Vehicle", "Boat" } }, { "Propellers", 3 }, { "Type", "Bertram 35" }, };
+        }
+
+
+        #endregion
+
+    }
+}

--- a/Mongo.Migration.Test/Mongo.Migration.Test.csproj
+++ b/Mongo.Migration.Test/Mongo.Migration.Test.csproj
@@ -61,6 +61,9 @@
       <HintPath>..\packages\MongoDB.Driver.Core.2.8.0\lib\net452\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="NSubstitute, Version=4.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca">
       <HintPath>..\packages\NSubstitute.4.1.0\lib\net46\NSubstitute.dll</HintPath>
@@ -98,6 +101,10 @@
   <ItemGroup>
     <Compile Include="Documents\Locators\AttributeMigrationLocator_when_locate.cs" />
     <Compile Include="IntegrationTest.cs" />
+    <Compile Include="TestDoubles\WithInheritance\Boat.cs" />
+    <Compile Include="TestDoubles\WithInheritance\Car.cs" />
+    <Compile Include="TestDoubles\WithInheritance\CarMigration_0_0_1.cs" />
+    <Compile Include="Migrations\CollectionRunner_when_migrating_a_typed_document.cs" />
     <Compile Include="Migrations\Locators\TypeMigrationLocator_when_locate.cs" />
     <Compile Include="Migrations\MigrationRunner_when_migrating_down.cs" />
     <Compile Include="Migrations\Migration_when_migrating.cs" />
@@ -127,8 +134,10 @@
     <Compile Include="TestDoubles\TestDocumentWithTwoMigration_0_0_1.cs" />
     <Compile Include="TestDoubles\TestDocumentWithOneMigration_0_0_1.cs" />
     <Compile Include="TestDoubles\TestDocumentWithTwoMigration.cs" />
+    <Compile Include="TestDoubles\WithInheritance\Vehicle.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Mongo.Migration.Test/Mongo.Migration.Test.csproj
+++ b/Mongo.Migration.Test/Mongo.Migration.Test.csproj
@@ -44,6 +44,9 @@
       <HintPath>..\packages\FluentAssertions.5.6.0\lib\net47\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="LightInject, Version=6.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.6.4.0\lib\net46\LightInject.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mongo2Go, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Mongo2Go.2.2.11\lib\netstandard1.6\Mongo2Go.dll</HintPath>
@@ -79,6 +82,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Configuration" />
+    <Reference Include="System.IO, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System.Linq.Expressions, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
       <Private>True</Private>
@@ -87,6 +93,7 @@
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading.Tasks, Version=4.0.11.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
       <Private>True</Private>

--- a/Mongo.Migration.Test/Services/Interceptors/MigrationInterceptorProvider_when_get_serializer.cs
+++ b/Mongo.Migration.Test/Services/Interceptors/MigrationInterceptorProvider_when_get_serializer.cs
@@ -25,7 +25,7 @@ namespace Mongo.Migration.Test.Services.Interceptors
         public void When_entity_is_document_Then_provide_serializer()
         {
             // Arrange 
-            var provider = _components.Get<MigrationInterceptorProvider>();
+            var provider = _components.Get<IMigrationInterceptorProvider>();
 
             // Act
             var serializer = provider.GetSerializer(typeof(TestDocumentWithOneMigration));
@@ -38,7 +38,7 @@ namespace Mongo.Migration.Test.Services.Interceptors
         public void When_entity_is_not_document_Then_provide_null()
         {
             // Arrange 
-            var provider = _components.Get<MigrationInterceptorProvider>();
+            var provider = _components.Get<IMigrationInterceptorProvider>();
 
             // Act
             var serializer = provider.GetSerializer(typeof(TestClass));

--- a/Mongo.Migration.Test/TestDoubles/WithInheritance/Boat.cs
+++ b/Mongo.Migration.Test/TestDoubles/WithInheritance/Boat.cs
@@ -1,0 +1,8 @@
+﻿namespace Mongo.Migration.Test.TestDoubles
+{
+    internal class Boat : Vehicle
+    {
+        public int Propellers { get; set; }
+
+    }
+}

--- a/Mongo.Migration.Test/TestDoubles/WithInheritance/Car.cs
+++ b/Mongo.Migration.Test/TestDoubles/WithInheritance/Car.cs
@@ -1,0 +1,11 @@
+﻿using Mongo.Migration.Documents.Attributes;
+
+namespace Mongo.Migration.Test.TestDoubles
+{
+
+    [StartUpVersion("0.0.1")]
+    internal class Car : Vehicle
+    {
+        public int Doors { get; set; }
+    }
+}

--- a/Mongo.Migration.Test/TestDoubles/WithInheritance/CarMigration_0_0_1.cs
+++ b/Mongo.Migration.Test/TestDoubles/WithInheritance/CarMigration_0_0_1.cs
@@ -1,0 +1,20 @@
+﻿using Mongo.Migration.Migrations;
+using MongoDB.Bson;
+
+namespace Mongo.Migration.Test.TestDoubles
+{
+    internal class CarMigration_0_0_1 : Migration<Car>
+    {
+        public CarMigration_0_0_1() : base("0.0.1")
+        {
+        }
+
+        public override void Up(BsonDocument document)
+        {
+        }
+
+        public override void Down(BsonDocument document)
+        {
+        }
+    }
+}

--- a/Mongo.Migration.Test/TestDoubles/WithInheritance/Vehicle.cs
+++ b/Mongo.Migration.Test/TestDoubles/WithInheritance/Vehicle.cs
@@ -1,0 +1,10 @@
+﻿using Mongo.Migration.Documents.Attributes;
+using Mongo.Migration.Documents;
+using MongoDB.Bson;
+
+namespace Mongo.Migration.Test.TestDoubles
+{
+    internal class Vehicle : Document
+    {
+    }
+}

--- a/Mongo.Migration.Test/app.config
+++ b/Mongo.Migration.Test/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Mongo.Migration.Test/packages.config
+++ b/Mongo.Migration.Test/packages.config
@@ -3,6 +3,7 @@
   <package id="Castle.Core" version="4.4.0" targetFramework="net47" />
   <package id="DnsClient" version="1.2.0" targetFramework="net47" />
   <package id="FluentAssertions" version="5.6.0" targetFramework="net47" />
+  <package id="LightInject" version="6.4.0" targetFramework="net47" />
   <package id="Mongo2Go" version="2.2.11" targetFramework="net47" />
   <package id="MongoDB.Bson" version="2.8.0" targetFramework="net47" />
   <package id="MongoDB.Driver" version="2.8.0" targetFramework="net47" />

--- a/Mongo.Migration.Test/packages.config
+++ b/Mongo.Migration.Test/packages.config
@@ -7,6 +7,7 @@
   <package id="MongoDB.Bson" version="2.8.0" targetFramework="net47" />
   <package id="MongoDB.Driver" version="2.8.0" targetFramework="net47" />
   <package id="MongoDB.Driver.Core" version="2.8.0" targetFramework="net47" />
+  <package id="Moq" version="4.13.1" targetFramework="net47" />
   <package id="NSubstitute" version="4.1.0" targetFramework="net47" />
   <package id="NUnit" version="3.11.0" targetFramework="net47" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net47" />

--- a/Mongo.Migration/Documents/Locators/RuntimeVersionLocator.cs
+++ b/Mongo.Migration/Documents/Locators/RuntimeVersionLocator.cs
@@ -6,7 +6,7 @@ using Mongo.Migration.Documents.Attributes;
 
 namespace Mongo.Migration.Documents.Locators
 {
-    internal class RuntimeVersionLocator : AbstractLocator<DocumentVersion, Type>, IRuntimeVersionLocator
+    public class RuntimeVersionLocator : AbstractLocator<DocumentVersion, Type>, IRuntimeVersionLocator
     {
         public override DocumentVersion? GetLocateOrNull(Type identifier)
         {

--- a/Mongo.Migration/Documents/Locators/StartUpVersionLocator.cs
+++ b/Mongo.Migration/Documents/Locators/StartUpVersionLocator.cs
@@ -6,7 +6,7 @@ using Mongo.Migration.Documents.Attributes;
 
 namespace Mongo.Migration.Documents.Locators
 {
-    internal class StartUpVersionLocator : AbstractLocator<DocumentVersion, Type>, IStartUpVersionLocator
+    public class StartUpVersionLocator : AbstractLocator<DocumentVersion, Type>, IStartUpVersionLocator
     {
         public override DocumentVersion? GetLocateOrNull(Type identifier)
         {

--- a/Mongo.Migration/Migrations/CollectionMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/CollectionMigrationRunner.cs
@@ -10,7 +10,7 @@ using MongoDB.Driver;
 
 namespace Mongo.Migration.Migrations
 {
-    internal class CollectionMigrationRunner : ICollectionMigrationRunner
+    public class CollectionMigrationRunner : ICollectionMigrationRunner
     {
         private readonly IMongoClient _client;
 

--- a/Mongo.Migration/Migrations/CollectionMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/CollectionMigrationRunner.cs
@@ -126,12 +126,21 @@ namespace Mongo.Migration.Migrations
         {
             var currentVersion = _versionService.GetCurrentOrLatestMigrationVersion(type);
 
-            var existFilter = Builders<BsonDocument>.Filter.Exists(_versionService.GetVersionFieldName(), false);
-            var notEqualFilter = Builders<BsonDocument>.Filter.Ne(
+            var versionExistFilter = Builders<BsonDocument>.Filter.Exists(_versionService.GetVersionFieldName(), false);
+
+            var versionNotEqualFilter = Builders<BsonDocument>.Filter.Ne(
                 _versionService.GetVersionFieldName(),
                 currentVersion);
 
-            return Builders<BsonDocument>.Filter.Or(existFilter, notEqualFilter);
+            var versionExistsOrDoesntMatchFilter = Builders<BsonDocument>.Filter.Or(versionExistFilter, versionNotEqualFilter);
+
+            var typeExistFilter = Builders<BsonDocument>.Filter.Exists("_t", false);
+            var typeEqualsFilter = Builders<BsonDocument>.Filter.AnyEq(
+                "_t", type.Name);
+
+            var typeExistsOrMatchsFilter = Builders<BsonDocument>.Filter.Or(typeExistFilter, typeEqualsFilter);
+
+            return Builders<BsonDocument>.Filter.And(versionExistsOrDoesntMatchFilter, typeExistsOrMatchsFilter);
         }
     }
 }

--- a/Mongo.Migration/Migrations/ICollectionMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/ICollectionMigrationRunner.cs
@@ -2,7 +2,7 @@ using MongoDB.Driver;
 
 namespace Mongo.Migration.Migrations
 {
-    internal interface ICollectionMigrationRunner
+    public interface ICollectionMigrationRunner
     {
         void RunAll();
     }

--- a/Mongo.Migration/Migrations/IMigration.cs
+++ b/Mongo.Migration/Migrations/IMigration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Mongo.Migration.Documents;
 using MongoDB.Bson;
 
@@ -13,5 +14,8 @@ namespace Mongo.Migration.Migrations
         void Up(BsonDocument document);
 
         void Down(BsonDocument document);
+
+        void Initialise();
+        
     }
 }

--- a/Mongo.Migration/Migrations/IMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/IMigrationRunner.cs
@@ -4,7 +4,7 @@ using MongoDB.Bson;
 
 namespace Mongo.Migration.Migrations
 {
-    internal interface IMigrationRunner
+    public interface IMigrationRunner
     {
         void Run(Type type, BsonDocument document, DocumentVersion to);
         

--- a/Mongo.Migration/Migrations/Locators/IMigrationLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/IMigrationLocator.cs
@@ -17,5 +17,9 @@ namespace Mongo.Migration.Migrations.Locators
         DocumentVersion GetLatestVersion(Type type);
 
         void Locate();
+
+        void LocateAndInitialiseMigrations();
+
+        void InitialiseMigrations();
     }
 }

--- a/Mongo.Migration/Migrations/Locators/MigrationLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/MigrationLocator.cs
@@ -24,7 +24,7 @@ namespace Mongo.Migration.Migrations.Locators
             get
             {
                 if (_migrations == null)
-                    Locate();
+                    LocateAndInitialiseMigrations();
                 
                 if (_migrations.NullOrEmpty())
                     throw new NoMigrationsFoundException();
@@ -81,7 +81,14 @@ namespace Mongo.Migration.Migrations.Locators
         }
 
         public abstract void Locate();
-        
+
+        public void LocateAndInitialiseMigrations()
+        {
+            Locate();
+            InitialiseMigrations();
+        }
+
+
         private static IEnumerable<Assembly> GetAssemblies()
         {
             var location = AppDomain.CurrentDomain.BaseDirectory;
@@ -96,6 +103,18 @@ namespace Mongo.Migration.Migrations.Locators
             assemblies.AddRange(migrationAssemblies);
 
             return assemblies;
+        }
+
+
+        public void InitialiseMigrations()
+        {
+            foreach (var migrationType in Migrations)
+            {
+                foreach (var migration in migrationType.Value)
+                {
+                    migration?.Initialise(); 
+                }
+            }
         }
     }
 }

--- a/Mongo.Migration/Migrations/Locators/TypeMigrationDependencyLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/TypeMigrationDependencyLocator.cs
@@ -6,7 +6,7 @@ using Mongo.Migration.Migrations.Adapters;
 
 namespace Mongo.Migration.Migrations.Locators
 {
-    internal class TypeMigrationDependencyLocator : MigrationLocator
+    public class TypeMigrationDependencyLocator : MigrationLocator
     {
         private readonly IContainerProvider _containerProvider;
 

--- a/Mongo.Migration/Migrations/Locators/TypeMigrationDependencyLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/TypeMigrationDependencyLocator.cs
@@ -24,6 +24,8 @@ namespace Mongo.Migration.Migrations.Locators
                 select type).Distinct();
 
             Migrations = migrationTypes.Select(GetMigrationInstance).ToMigrationDictionary();
+
+        
         }
 
         private IMigration GetMigrationInstance(Type type)

--- a/Mongo.Migration/Migrations/Migration.cs
+++ b/Mongo.Migration/Migrations/Migration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Mongo.Migration.Documents;
 using MongoDB.Bson;
 
@@ -18,5 +19,10 @@ namespace Mongo.Migration.Migrations
         public abstract void Up(BsonDocument document);
 
         public abstract void Down(BsonDocument document);
+
+        public virtual void Initialise() 
+        {
+            
+        }
     }
 }

--- a/Mongo.Migration/Migrations/MigrationRunner.cs
+++ b/Mongo.Migration/Migrations/MigrationRunner.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson;
 
 namespace Mongo.Migration.Migrations
 {
-    internal class MigrationRunner : IMigrationRunner
+    public class MigrationRunner : IMigrationRunner
     {
         private readonly IMigrationLocator _migrationLocator;
 

--- a/Mongo.Migration/MongoMigration.cs
+++ b/Mongo.Migration/MongoMigration.cs
@@ -4,7 +4,7 @@ using Mongo.Migration.Services;
 
 namespace Mongo.Migration
 {
-    internal class MongoMigration : IMongoMigration
+    public class MongoMigration : IMongoMigration
     {
         private readonly ICollectionLocator _collectionLocator;
         private readonly IStartUpVersionLocator _startUpVersionLocator;

--- a/Mongo.Migration/MongoMigration.cs
+++ b/Mongo.Migration/MongoMigration.cs
@@ -24,7 +24,7 @@ namespace Mongo.Migration
 
         public void Run()
         {
-            _migrationLocator.Locate();
+            _migrationLocator.LocateAndInitialiseMigrations();
             _runtimeVersionLocator.Locate();
             _collectionLocator.Locate();
             _startUpVersionLocator.Locate();

--- a/Mongo.Migration/Services/IMigrationService.cs
+++ b/Mongo.Migration/Services/IMigrationService.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mongo.Migration.Services
 {
-    internal interface IMigrationService
+    public interface IMigrationService
     {
         void Migrate();
     }

--- a/Mongo.Migration/Services/Interceptors/IMigrationInterceptorFactory.cs
+++ b/Mongo.Migration/Services/Interceptors/IMigrationInterceptorFactory.cs
@@ -3,7 +3,7 @@ using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
 {
-    internal interface IMigrationInterceptorFactory
+    public interface IMigrationInterceptorFactory
     {
         IBsonSerializer Create(Type type);
     }

--- a/Mongo.Migration/Services/Interceptors/IMigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/IMigrationInterceptorProvider.cs
@@ -1,0 +1,8 @@
+﻿using MongoDB.Bson.Serialization;
+
+namespace Mongo.Migration.Services.Interceptors
+{
+    public interface IMigrationInterceptorProvider : IBsonSerializationProvider
+    {
+    }
+}

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorFactory.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorFactory.cs
@@ -4,7 +4,7 @@ using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
 {
-    internal class MigrationInterceptorFactory : IMigrationInterceptorFactory
+    public class MigrationInterceptorFactory : IMigrationInterceptorFactory
     {
         private readonly IMigrationRunner _migrationRunner;
         private readonly IVersionService _versionService;

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
@@ -5,7 +5,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
-
+{ 
     internal class MigrationInterceptorProvider : IMigrationInterceptorProvider
     {
         private readonly IMigrationInterceptorFactory _migrationInterceptorFactory;

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
@@ -6,7 +6,7 @@ using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
 { 
-    internal class MigrationInterceptorProvider : IMigrationInterceptorProvider
+    public class MigrationInterceptorProvider : IMigrationInterceptorProvider
     {
         private readonly IMigrationInterceptorFactory _migrationInterceptorFactory;
 

--- a/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
+++ b/Mongo.Migration/Services/Interceptors/MigrationInterceptorProvider.cs
@@ -5,8 +5,8 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services.Interceptors
-{
-    internal class MigrationInterceptorProvider : IBsonSerializationProvider
+
+    internal class MigrationInterceptorProvider : IMigrationInterceptorProvider
     {
         private readonly IMigrationInterceptorFactory _migrationInterceptorFactory;
 

--- a/Mongo.Migration/Services/MigrationService.cs
+++ b/Mongo.Migration/Services/MigrationService.cs
@@ -8,14 +8,14 @@ using MongoDB.Bson.Serialization;
 
 namespace Mongo.Migration.Services
 {
-    internal class MigrationService : IMigrationService
+    public class MigrationService : IMigrationService
     {
         private readonly ILogger<MigrationService> _logger;
         private readonly ICollectionMigrationRunner _migrationRunner;
-        private readonly MigrationInterceptorProvider _provider;
+        private readonly IMigrationInterceptorProvider _provider;
         private readonly DocumentVersionSerializer _serializer;
 
-        public MigrationService(DocumentVersionSerializer serializer, MigrationInterceptorProvider provider,
+        public MigrationService(DocumentVersionSerializer serializer, IMigrationInterceptorProvider provider,
             ICollectionMigrationRunner migrationRunner)
             : this(serializer, provider, NullLoggerFactory.Instance)
         {
@@ -24,7 +24,7 @@ namespace Mongo.Migration.Services
 
         private MigrationService(
             DocumentVersionSerializer serializer,
-            MigrationInterceptorProvider provider,
+            IMigrationInterceptorProvider provider,
             ILoggerFactory loggerFactory)
         {
             _serializer = serializer;

--- a/Mongo.Migration/Services/VersionService.cs
+++ b/Mongo.Migration/Services/VersionService.cs
@@ -11,7 +11,7 @@ using MongoDB.Bson;
 
 namespace Mongo.Migration.Services
 {
-    internal class VersionService : IVersionService
+    public class VersionService : IVersionService
     {
         private static readonly string VERSION_FIELD_NAME = "Version";
 

--- a/Mongo.Migration/Startup/DotNetCore/MongoMigrationExtensions.cs
+++ b/Mongo.Migration/Startup/DotNetCore/MongoMigrationExtensions.cs
@@ -37,7 +37,7 @@ namespace Mongo.Migration.Startup.DotNetCore
 
             services.AddTransient<ICollectionMigrationRunner, CollectionMigrationRunner>();
             services.AddTransient<IMigrationRunner, MigrationRunner>();
-            services.AddTransient<MigrationInterceptorProvider, MigrationInterceptorProvider>();
+            services.AddTransient<IMigrationInterceptorProvider, MigrationInterceptorProvider>();
 
             services.AddTransient<IMongoMigration, MongoMigration>();
             services.AddTransient<IStartupFilter, MongoMigrationStartupFilter>();

--- a/Mongo.Migration/Startup/Static/ComponentRegistry.cs
+++ b/Mongo.Migration/Startup/Static/ComponentRegistry.cs
@@ -57,7 +57,7 @@ namespace Mongo.Migration.Startup.Static
 
             _containerAdapter.Register<ICollectionMigrationRunner, CollectionMigrationRunner>();
             _containerAdapter.Register<IMigrationRunner, MigrationRunner>();
-            _containerAdapter.Register<MigrationInterceptorProvider, MigrationInterceptorProvider>();
+            _containerAdapter.Register<IMigrationInterceptorProvider, MigrationInterceptorProvider>();
 
             _containerAdapter.Register<IMongoMigration, MongoMigration>();
         }


### PR DESCRIPTION
When a collection contains more than one type the current migrations migrate all documents. This PR addresses that by restricting the document query to filter any documents that dont have a type or that match the exact type. #26