### PR TITLE
Make DocumentVersion compatible with Json Deserialization.  

### DIFF
--- a/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
+++ b/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+	  <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+	  <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Mongo.Migration.Test\**\*.cs" />
@@ -20,6 +21,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NSubstitute" Version="4.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/Mongo.Migration/Documents/DocumentVersion.cs
+++ b/Mongo.Migration/Documents/DocumentVersion.cs
@@ -9,11 +9,11 @@ namespace Mongo.Migration.Documents
 
         private const int MAX_LENGTH = 3;
 
-        public int Major { get; set; }
+        public int Major { get; init; }
 
-        public int Minor { get; set; }
+        public int Minor { get; init; }
 
-        public int Revision { get; set; }
+        public int Revision { get; init; }
 
         public DocumentVersion(string version)
         {

--- a/Mongo.Migration/Documents/DocumentVersion.cs
+++ b/Mongo.Migration/Documents/DocumentVersion.cs
@@ -9,11 +9,11 @@ namespace Mongo.Migration.Documents
 
         private const int MAX_LENGTH = 3;
 
-        public readonly int Major;
+        public int Major { get; private set; }
 
-        public readonly int Minor;
+        public int Minor { get; private set; }
 
-        public readonly int Revision;
+        public int Revision { get; private set; }
 
         public DocumentVersion(string version)
         {
@@ -24,11 +24,11 @@ namespace Mongo.Migration.Documents
                 throw new VersionStringToLongException(version);
             }
 
-            ParseVersionPart(versionParts[0], out Major);
+            Major = ParseVersionPart(versionParts[0]);
 
-            ParseVersionPart(versionParts[1], out Minor);
+            Minor = ParseVersionPart(versionParts[1]);
 
-            ParseVersionPart(versionParts[2], out Revision);
+            Revision = ParseVersionPart(versionParts[2]);
         }
 
         public DocumentVersion(int major, int minor, int revision)
@@ -142,13 +142,14 @@ namespace Mongo.Migration.Documents
 
         #region parse operations
 
-        private static void ParseVersionPart(string value, out int target)
+        private static int ParseVersionPart(string value)
         {
             string revisionString = value;
-            if (!int.TryParse(revisionString, out target))
+            if (!int.TryParse(revisionString, out var target))
             {
                 throw new InvalidVersionValueException(revisionString);
             }
+            return target;
         }
 
         #endregion

--- a/Mongo.Migration/Documents/DocumentVersion.cs
+++ b/Mongo.Migration/Documents/DocumentVersion.cs
@@ -9,11 +9,11 @@ namespace Mongo.Migration.Documents
 
         private const int MAX_LENGTH = 3;
 
-        public int Major { get; private set; }
+        public int Major { get; set; }
 
-        public int Minor { get; private set; }
+        public int Minor { get; set; }
 
-        public int Revision { get; private set; }
+        public int Revision { get; set; }
 
         public DocumentVersion(string version)
         {

--- a/Mongo.Migration/Mongo.Migration.csproj
+++ b/Mongo.Migration/Mongo.Migration.csproj
@@ -5,8 +5,13 @@
     <Version>3.1.4</Version>
     <PackageVersion>3.1.4</PackageVersion>
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="LightInject" Version="5.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />


### PR DESCRIPTION
If the fields are not public properties they won't get used by either System.Text.Json or Netwonsoft.Json.  This makes them still readonly, and compatible with deserialization of json without writing a custom JsonConverter.