### PR TITLE
Fix downward migrations / allow initialization without both ClientSettings if ConnectionString and DatabaseName have been provided

### DIFF
--- a/Mongo.Migration/Migrations/Database/DatabaseMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/Database/DatabaseMigrationRunner.cs
@@ -97,6 +97,11 @@ namespace Mongo.Migration.Migrations.Database
                 {
                     break;
                 }
+                else if (migration.Version > currentVersion) // a migration that was never applied
+                {
+                    this._logger.LogInformation("Skipping Migration Down: {0}:{1} because current version is {2} ", migration.GetType().ToString(), migration.Version, currentVersion);
+                    continue;
+                }
 
                 this._logger.LogInformation("Database Migration Down: {0}:{1} ", migration.GetType().ToString(), migration.Version);
 

--- a/Mongo.Migration/Migrations/Database/StartUpDatabaseMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/Database/StartUpDatabaseMigrationRunner.cs
@@ -27,7 +27,7 @@ namespace Mongo.Migration.Migrations.Database
                 collectionLocator,
                 migrationRunner)
         {
-            if (settings.ConnectionString == null && settings.Database == null || settings.ClientSettings == null)
+            if ((settings.ConnectionString == null || settings.ClientSettings == null) && settings.Database == null)
             {
                 throw new MongoMigrationNoMongoClientException();
             }

--- a/Mongo.Migration/Migrations/Document/StartUpDocumentMigrationRunner.cs
+++ b/Mongo.Migration/Migrations/Document/StartUpDocumentMigrationRunner.cs
@@ -34,7 +34,7 @@ namespace Mongo.Migration.Migrations.Document
                 documentVersionService,
                 migrationRunner)
         {
-            if (settings.ConnectionString == null && settings.Database == null || settings.ClientSettings == null)
+            if ((settings.ConnectionString == null || settings.ClientSettings == null) && settings.Database == null)
             {
                 throw new MongoMigrationNoMongoClientException();
             }


### PR DESCRIPTION
This PR solves two issues:

1) When downgrading the database version by setting `MongoMigrationSettings.DatabaseMigrationVersion`, the `DatabaseMigrationRunner` would run not only migrations with a version that is smaller than `currentVersion`, but any version that is not equal to `toVersion`.

2) On .Net core, when you're providing a `ConnectionString` and `Database `in the `MongoMigrationSettings`, initialization would fail because of two checks that `MongoMigrationSettings` incorrectly enforce that both `MongoMigrationSettings.ConnectionString` and `MongoMigrationSettings.ClientSettings` be populated. Subsequent code shows that this isn't what was intended - initialization was prepared for both cases: when there's only a `ConnectionString` and when there's only `ClientSettings` . Hence I changed the initialization checks accordingly to allow initialization if only one of `ConnectionString`  / `ClientSettings`  is provided in `MongoMigrationSettings`.